### PR TITLE
Data Generation v3: Fix parallel rng + PowerFlowData train/val/test split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ results/
 wandb/
 outtest.txt
 runs.bat
+
+# Dataset files
+data

--- a/dataset_generator_pandapower_v2.py
+++ b/dataset_generator_pandapower_v2.py
@@ -26,7 +26,7 @@ def create_case3():
     
     return net
 
-number_of_samples = 2000
+number_of_samples = 30000
 number_of_processes = 10
 
 parser = argparse.ArgumentParser(prog='Power Flow Data Generator', description='')
@@ -52,6 +52,8 @@ else:
     exit()
 if num_lines_to_remove > 0 or num_lines_to_add > 0:
     complete_case_name = 'case' + case + 'perturbed' + f'{num_lines_to_remove:1d}' + 'r' + f'{num_lines_to_add:1d}' + 'a'
+else:
+    complete_case_name = 'case' + case
 base_net = base_net_create()
 base_net.bus['name'] = base_net.bus.index
 print(base_net.bus)
@@ -83,8 +85,10 @@ def unify_vn(net):
 
 def get_trafo_z_pu(net):
     for trafo_id in net.trafo.index:
-        net.trafo['i0_percent'][trafo_id] = 0.
-        net.trafo['pfe_kw'][trafo_id] = 0.
+        # net.trafo['i0_percent'][trafo_id] = 0.
+        # net.trafo['pfe_kw'][trafo_id] = 0.
+        net.trafo[trafo_id, 'i0_percent'] = 0.
+        net.trafo[trafo_id, 'pfe_kw'] = 0.
     
     z_pu = net.trafo['vk_percent'].values / 100. * 1000. / net.sn_mva
     r_pu = net.trafo['vkr_percent'].values / 100. * 1000. / net.sn_mva

--- a/dataset_generator_pandapower_v2.py
+++ b/dataset_generator_pandapower_v2.py
@@ -26,7 +26,7 @@ def create_case3():
     
     return net
 
-number_of_samples = 30000
+number_of_samples = 2000
 number_of_processes = 10
 
 parser = argparse.ArgumentParser(prog='Power Flow Data Generator', description='')
@@ -115,7 +115,7 @@ def get_adjacency_matrix(net):
     
     return A
 
-def generate_data(sublist_size):
+def generate_data(sublist_size, rng):
     edge_features_list = []
     node_features_x_list = []
     node_features_y_list = []
@@ -146,21 +146,22 @@ def generate_data(sublist_size):
         Pd = net.load['p_mw'].values
         Qd = net.load['q_mvar'].values
 
-        r = np.random.uniform(0.8*r, 1.2*r, r.shape[0])
-        x = np.random.uniform(0.8*x, 1.2*x, x.shape[0])
+        # rng = np.random.default_rng()
+        r = rng.uniform(0.8*r, 1.2*r, r.shape[0])
+        x = rng.uniform(0.8*x, 1.2*x, x.shape[0])
         # c = np.random.uniform(0.8*c, 1.2*c, c.shape[0])
-        le = np.random.uniform(0.8*le, 1.2*le, le.shape[0])
+        le = rng.uniform(0.8*le, 1.2*le, le.shape[0])
         
         # tau = np.random.uniform(0.8*tau, 1.2*tau, case['branch'].shape[0])
         # angle = np.random.uniform(-0.2, 0.2, case['branch'].shape[0])
     
-        Vg = np.random.uniform(1.00, 1.05, net.gen['vm_pu'].shape[0])
-        Pg = np.random.normal(Pg, 0.1*np.abs(Pg), net.gen['p_mw'].shape[0])
+        Vg = rng.uniform(1.00, 1.05, net.gen['vm_pu'].shape[0])
+        Pg = rng.normal(Pg, 0.1*np.abs(Pg), net.gen['p_mw'].shape[0])
         
         # Pd = np.random.uniform(0.5*Pd, 1.5*Pd, net.load['p_mw'].shape[0])
-        Pd = np.random.normal(Pd, 0.1*np.abs(Pd), net.load['p_mw'].shape[0])
+        Pd = rng.normal(Pd, 0.1*np.abs(Pd), net.load['p_mw'].shape[0])
         # Qd = np.random.uniform(0.5*Qd, 1.5*Qd, net.load['q_mvar'].shape[0])
-        Qd = np.random.normal(Qd, 0.1*np.abs(Qd), net.load['q_mvar'].shape[0])
+        Qd = rng.normal(Qd, 0.1*np.abs(Qd), net.load['q_mvar'].shape[0])
         
         net.line['r_ohm_per_km'] = r 
         net.line['x_ohm_per_km'] = x 
@@ -259,8 +260,11 @@ def generate_data(sublist_size):
 
 def generate_data_parallel(num_samples, num_processes):
     sublist_size = num_samples // num_processes
+    parent_rng = np.random.default_rng(123456)
+    streams = parent_rng.spawn(num_processes)
     pool = mp.Pool(processes=num_processes)
-    results = pool.map(generate_data, [sublist_size]*num_processes)
+    args = [[sublist_size, st] for st in streams]
+    results = pool.starmap(generate_data, args)
     pool.close()
     pool.join()
     

--- a/datasets/PowerFlowData.py
+++ b/datasets/PowerFlowData.py
@@ -110,7 +110,11 @@ class PowerFlowData(InMemoryDataset):
                 transform: Optional[Callable] = None, 
                 pre_transform: Optional[Callable] = None, 
                 pre_filter: Optional[Callable] = None,
-                normalize=True):
+                normalize=True,
+                xymean=None,
+                xystd=None,
+                edgemean=None,
+                edgestd=None):
 
         assert len(split) == 3
         assert task in ["train", "val", "test"]
@@ -118,10 +122,21 @@ class PowerFlowData(InMemoryDataset):
         self.case = case  # THIS MUST BE EXECUTED BEFORE super().__init__() since it is used in raw_file_names and processed_file_names
         self.split = split
         self.task = task
-        super().__init__(root, transform, pre_transform, pre_filter)
+        super().__init__(root, transform, pre_transform, pre_filter) # self.process runs here
         self.mask = torch.tensor([])
+        # assign mean,std if specified
+        if xymean is not None and xystd is not None:
+            self.xymean, self.xystd = xymean, xystd
+            print('xymean, xystd assigned.')
+        else:
+            self.xymean, self.xystd = None, None
+        if edgemean is not None and edgestd is not None:
+            self.edgemean, self.edgestd = edgemean, edgestd
+            print('edgemean, edgestd assigned.')
+        else:
+            self.edgemean, self.edgestd = None, None
         self.data, self.slices, self.mask = self._normalize_dataset(
-            *torch.load(self.processed_paths[0]))  # necessary, do not forget!
+            *torch.load(self.processed_paths[self.split_order[self.task]]))  # necessary, do not forget!
 
     def get_data_dimensions(self):
         return self[0].x.shape[1], self[0].y.shape[1], self[0].edge_attr.shape[1]
@@ -130,11 +145,10 @@ class PowerFlowData(InMemoryDataset):
         assert self.normalize == True
         return self.xymean[:1, :], self.xystd[:1, :], self.edgemean[:1, :], self.edgestd[:1, :]
 
-    def _normalize_dataset(self, data, slices) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _normalize_dataset(self, data, slices, ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if not self.normalize:
             # TODO an actual mask, perhaps never necessary though
             return data, slices, torch.tensor([])
-
         # selecting the right features
         # for x
         print(data.x.shape)
@@ -154,23 +168,21 @@ class PowerFlowData(InMemoryDataset):
 
         # normalizing
         # for node attributes
-        xy = torch.concat([data.x[:, 4:], data.y], dim=0)
-        # 6 for:
-        mean = torch.mean(xy, dim=0).unsqueeze(
-            dim=0).expand(data.x.shape[0], 6)
-        std = torch.std(xy, dim=0).unsqueeze(dim=0).expand(
-            data.x.shape[0], 6)  # Vm, Va, Pd, Qd, Gs, Bs
-        self.xymean, self.xystd = mean, std
-        # + 0.0000001 to avoid NaN's because of division by zero
-        data.x[:, 4:] = (data.x[:, 4:] - mean) / (std + 0.0000001)
-        data.y = (data.y - mean) / (std + 0.0000001)
+        if self.xymean is None or self.xystd is None:
+            xy = torch.concat([data.x[:, 4:], data.y], dim=0)
+            # 6 for:
+            mean = torch.mean(xy, dim=0, keepdim=True)
+            std = torch.std(xy, dim=0, keepdim=True)
+            self.xymean, self.xystd = mean, std
+            # + 0.0000001 to avoid NaN's because of division by zero
+        data.x[:, 4:] = (data.x[:, 4:] - self.xymean) / (self.xystd + 0.0000001)
+        data.y = (data.y - self.xymean) / (self.xystd + 0.0000001)
         # for edge attributes
-        mean = torch.mean(data.edge_attr, dim=0).unsqueeze(dim=0).expand(
-            data.edge_attr.shape[0], data.edge_attr.shape[1])
-        std = torch.std(data.edge_attr, dim=0).unsqueeze(dim=0).expand(
-            data.edge_attr.shape[0], data.edge_attr.shape[1])
-        self.edgemean, self.edgestd = mean, std
-        data.edge_attr = (data.edge_attr - mean) / (std + 0.0000001)
+        if self.edgemean is None or self.edgestd is None:
+            mean = torch.mean(data.edge_attr, dim=0, keepdim=True)
+            std = torch.std(data.edge_attr, dim=0, keepdim=True)
+            self.edgemean, self.edgestd = mean, std
+        data.edge_attr = (data.edge_attr - self.edgemean) / (self.edgestd + 0.0000001)
 
         # adding the mask
         # where x and y are unequal, the network must predict
@@ -190,7 +202,11 @@ class PowerFlowData(InMemoryDataset):
 
     @property
     def processed_file_names(self) -> List[str]:
-        return ["case"+f"{self.case}"+"_processed_data.pt"]
+        return [
+            "case"+f"{self.case}"+"_processed_train.pt",
+            "case"+f"{self.case}"+"_processed_val.pt",
+            "case"+f"{self.case}"+"_processed_test.pt",
+        ]
 
     def len(self):
         return self.slices['x'].shape[0]-1
@@ -202,41 +218,46 @@ class PowerFlowData(InMemoryDataset):
         # then use from_scipy_sparse_matrix()
         assert len(self.raw_paths) % 3 == 0
         raw_paths_per_case = [[self.raw_paths[i], self.raw_paths[i+1], self.raw_paths[i+2],] for i in range(0, len(self.raw_paths), 3)]
-        data_list = []
+        all_case_data = [[],[],[]]
         for case, raw_paths in enumerate(raw_paths_per_case):
-            # adj_mat = dense_to_sparse(torch.from_numpy(np.load(raw_paths[0])))
+            # process multiple cases (if specified) e.g. cases = [14, 118]
             edge_features = torch.from_numpy(np.load(raw_paths[0])).float()
             node_features_x = torch.from_numpy(np.load(raw_paths[1])).float()
             node_features_y = torch.from_numpy(np.load(raw_paths[2])).float()
 
+            assert self.split is not None
             if self.split is not None:
                 split_len = [int(len(node_features_x) * i) for i in self.split]
-                edge_features = torch.split(edge_features, split_len, dim=0)[
-                    self.split_order[self.task]]
-                node_features_x = torch.split(node_features_x, split_len, dim=0)[
-                    self.split_order[self.task]]
-                node_features_y = torch.split(node_features_y, split_len, dim=0)[
-                    self.split_order[self.task]]
-
-            per_case_data_list = [
-                Data(
-                    x=node_features_x[i],
-                    y=node_features_y[i],
-                    edge_index=edge_features[i, :, 0:2].T.to(torch.long)-1,
-                    edge_attr=edge_features[i, :, 2:],
-                ) for i in range(len(node_features_x))
-            ]
             
-            data_list.extend(per_case_data_list)
+            split_edge_features = torch.split(edge_features, split_len, dim=0)
+            split_node_features_x = torch.split(node_features_x, split_len, dim=0)
+            split_node_features_y = torch.split(node_features_y, split_len, dim=0)
+            
+            for idx in range(len(split_edge_features)):
+                # for each case, process train, val, test split
+                x = split_node_features_x[idx]
+                y = split_node_features_y[idx]
+                e = split_edge_features[idx]
+                data_list = [
+                    Data(
+                        x=x[i],
+                        y=y[i],
+                        edge_index=e[i, :, 0:2].T.to(torch.long)-1,
+                        edge_attr=e[i, :, 2:],
+                    ) for i in range(len(x))
+                ]
 
-        if self.pre_filter is not None:  # filter out some data
-            data_list = [data for data in data_list if self.pre_filter(data)]
+                if self.pre_filter is not None:  # filter out some data
+                    data_list = [data for data in data_list if self.pre_filter(data)]
 
-        if self.pre_transform is not None:
-            data_list = [self.pre_transform(data) for data in data_list]
+                if self.pre_transform is not None:
+                    data_list = [self.pre_transform(data) for data in data_list]
+                    
+                all_case_data[idx].extend(data_list)
 
-        data, slices = self.collate(data_list)
-        torch.save((data, slices), self.processed_paths[0])
+        for idx, case_data in enumerate(all_case_data):
+            data, slices = self.collate(case_data)
+            torch.save((data, slices), self.processed_paths[idx])
 
 
 def main():

--- a/test.py
+++ b/test.py
@@ -19,7 +19,7 @@ SAVE_DIR = 'models'
 
 @torch.no_grad()
 def main():
-    run_id = '20230628-6312'
+    run_id = '20230627-9288'
     models = {
         'MPN': MPN,
         'MPN_simplenet': MPN_simplenet,
@@ -37,8 +37,15 @@ def main():
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
+    data_param_path = os.path.join(data_dir, 'params', f'data_params_{run_id}.pt')
+    
+    data_param = torch.load(data_param_path, map_location='cpu')
+    xymean, xystd = data_param['xymean'], data_param['xystd']
+    edgemean, edgestd = data_param['edgemean'], data_param['edgestd']
+        
     testset = PowerFlowData(root=data_dir, case=grid_case,
-                            split=[.5, .2, .3], task='test')
+                            split=[.5, .2, .3], task='test',
+                            xymean=xymean, xystd=xystd, edgemean=edgemean, edgestd=edgestd)
     test_loader = DataLoader(testset, batch_size=batch_size, shuffle=False)
     
     pwr_imb_loss = PowerImbalance(*testset.get_data_means_stds()).to(device)

--- a/train.py
+++ b/train.py
@@ -76,6 +76,15 @@ def main():
     trainset = PowerFlowData(root=data_dir, case=grid_case, split=[.5, .2, .3], task='train', normalize=nomalize_data)
     valset = PowerFlowData(root=data_dir, case=grid_case, split=[.5, .2, .3], task='val', normalize=nomalize_data)
     testset = PowerFlowData(root=data_dir, case=grid_case, split=[.5, .2, .3], task='test', normalize=nomalize_data)
+    
+    # save normalizing params
+    os.makedirs(os.path.join(data_dir, 'params'), exist_ok=True)
+    torch.save({
+            'xymean': trainset.xymean,
+            'xystd': trainset.xystd,
+            'edgemean': trainset.edgemean,
+            'edgestd': trainset.edgestd,
+        }, os.path.join(data_dir, 'params', f'data_params_{run_id}.pt'))
         
     train_loader = DataLoader(trainset, batch_size=batch_size, shuffle=True)
     val_loader = DataLoader(valset, batch_size=batch_size, shuffle=False)


### PR DESCRIPTION
**What's Changed:**
- Correct parallel rng: np.random.uniform (e.g.) -> np.random.default_rng + rng.spawn + child_rng.uniform
- Fix PowerFlowData class definition for correct train, val, test split.
- Save and load normalizing parameters in training and testing respectively.

@StavrosOrf 